### PR TITLE
NGC members map

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
     "@astrojs/check": "^0.9.6",
     "@fontsource-variable/source-sans-3": "^5.2.9",
     "@fontsource-variable/space-grotesk": "^5.2.10",
+    "@turf/centroid": "^7.3.1",
+    "@turf/helpers": "^7.3.1",
     "astro": "^5.16.6",
+    "maplibre-gl": "^5.15.0",
     "sharp": "^0.34.4",
     "typescript": "^5.9.2"
   },
-  "packageManager": "pnpm@10.11.0"
+  "packageManager": "pnpm@10.26.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,18 @@ importers:
       '@fontsource-variable/space-grotesk':
         specifier: ^5.2.10
         version: 5.2.10
+      '@turf/centroid':
+        specifier: ^7.3.1
+        version: 7.3.1
+      '@turf/helpers':
+        specifier: ^7.3.1
+        version: 7.3.1
       astro:
         specifier: ^5.16.6
         version: 5.16.6(@types/node@24.0.15)(jiti@2.4.2)(rollup@4.45.1)(typescript@5.9.2)(yaml@2.8.0)
+      maplibre-gl:
+        specifier: ^5.15.0
+        version: 5.15.0
       sharp:
         specifier: ^0.34.4
         version: 0.34.4
@@ -406,6 +415,40 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@mapbox/geojson-rewind@0.5.2':
+    resolution: {integrity: sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==}
+    hasBin: true
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2':
+    resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
+    engines: {node: '>= 0.6'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.0.7':
+    resolution: {integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/vector-tile@2.0.4':
+    resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/maplibre-gl-style-spec@24.4.1':
+    resolution: {integrity: sha512-UKhA4qv1h30XT768ccSv5NjNCX+dgfoq2qlLVmKejspPcSQTYD4SrVucgqegmYcKcmwf06wcNAa/kRd0NHWbUg==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.2':
+    resolution: {integrity: sha512-SQKdJ909VGROkA6ovJgtHNs9YXV4YXUPS+VaZ50I2Mt951SLlUm2Cv34x5Xwc1HiFlsd3h2Yrs5cn7xzqBmENw==}
+
+  '@maplibre/vt-pbf@4.2.0':
+    resolution: {integrity: sha512-bxrk/kQUwWXZgmqYgwOCnZCMONCRi3MJMqJdza4T3E4AeR5i+VyMnaJ8iDWtWxdfEAJRtrzIOeJtxZSy5mFrFA==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -554,6 +597,15 @@ packages:
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
 
+  '@turf/centroid@7.3.1':
+    resolution: {integrity: sha512-hRnsDdVBH4pX9mAjYympb2q5W8TCMUMNEjcRrAF7HTCyjIuRmjJf8vUtlzf7TTn9RXbsvPc1vtm3kLw20Jm8DQ==}
+
+  '@turf/helpers@7.3.1':
+    resolution: {integrity: sha512-zkL34JVhi5XhsuMEO0MUTIIFEJ8yiW1InMu4hu/oRqamlY4mMoZql0viEmH6Dafh/p+zOl8OYvMJ3Vm3rFshgg==}
+
+  '@turf/meta@7.3.1':
+    resolution: {integrity: sha512-NWsfOE5RVtWpLQNkfOF/RrYvLRPwwruxhZUV0UFIzHqfiRJ50aO9Y6uLY4bwCUe2TumLJQSR4yaoA72Rmr2mnQ==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -562,6 +614,12 @@ packages:
 
   '@types/fontkit@2.0.8':
     resolution: {integrity: sha512-wN+8bYxIpJf+5oZdrdtaX04qUuWHcKxcDEgRS9Qm9ZClSHjzEn13SxUC+5eRM+4yXIeTYk8mTzLAWGF64847ew==}
+
+  '@types/geojson-vt@3.2.5':
+    resolution: {integrity: sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -577,6 +635,9 @@ packages:
 
   '@types/node@24.0.15':
     resolution: {integrity: sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -849,6 +910,9 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
   emmet@2.4.11:
     resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
 
@@ -943,6 +1007,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  geojson-vt@4.0.2:
+    resolution: {integrity: sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -951,8 +1018,15 @@ packages:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1051,11 +1125,17 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   jsonc-parser@2.3.1:
     resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  kdbush@4.0.2:
+    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -1079,6 +1159,10 @@ packages:
 
   magicast@0.5.1:
     resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
+
+  maplibre-gl@5.15.0:
+    resolution: {integrity: sha512-pPeu/t4yPDX/+Uf9ibLUdmaKbNMlGxMAX+tBednYukol2qNk2TZXAlhdohWxjVvTO3is8crrUYv3Ok02oAaKzA==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -1220,6 +1304,9 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -1229,6 +1316,9 @@ packages:
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1297,6 +1387,10 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  pbf@4.0.1:
+    resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+    hasBin: true
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -1314,6 +1408,9 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
 
   prettier@3.7.4:
     resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
@@ -1334,8 +1431,14 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  protocol-buffers-schema@3.6.0:
+    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -1395,6 +1498,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   restructure@3.0.2:
     resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
@@ -1421,6 +1527,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   sax@1.4.3:
     resolution: {integrity: sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==}
@@ -1475,6 +1584,9 @@ packages:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
 
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
+
   svgo@4.0.0:
     resolution: {integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==}
     engines: {node: '>=16'}
@@ -1490,6 +1602,9 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2178,6 +2293,51 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@mapbox/geojson-rewind@0.5.2':
+    dependencies:
+      get-stream: 6.0.1
+      minimist: 1.2.8
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.0.7': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/vector-tile@2.0.4':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.1
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/maplibre-gl-style-spec@24.4.1':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      rw: 1.3.3
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.2':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.2.0':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/vector-tile': 2.0.4
+      '@types/geojson-vt': 3.2.5
+      '@types/supercluster': 7.1.3
+      geojson-vt: 4.0.2
+      pbf: 4.0.1
+      supercluster: 8.0.1
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2297,6 +2457,23 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@turf/centroid@7.3.1':
+    dependencies:
+      '@turf/helpers': 7.3.1
+      '@turf/meta': 7.3.1
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/helpers@7.3.1':
+    dependencies:
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/meta@7.3.1':
+    dependencies:
+      '@turf/helpers': 7.3.1
+      '@types/geojson': 7946.0.16
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -2306,6 +2483,12 @@ snapshots:
   '@types/fontkit@2.0.8':
     dependencies:
       '@types/node': 24.0.15
+
+  '@types/geojson-vt@3.2.5':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -2324,6 +2507,10 @@ snapshots:
   '@types/node@24.0.15':
     dependencies:
       undici-types: 7.8.0
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/unist@3.0.3': {}
 
@@ -2676,6 +2863,8 @@ snapshots:
 
   dset@3.1.4: {}
 
+  earcut@3.0.2: {}
+
   emmet@2.4.11:
     dependencies:
       '@emmetio/abbreviation': 2.3.3
@@ -2784,11 +2973,17 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  geojson-vt@4.0.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.3.0: {}
 
+  get-stream@6.0.1: {}
+
   github-slugger@2.0.0: {}
+
+  gl-matrix@3.4.4: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -2934,9 +3129,13 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   jsonc-parser@2.3.1: {}
 
   jsonc-parser@3.3.1: {}
+
+  kdbush@4.0.2: {}
 
   kleur@3.0.3: {}
 
@@ -2957,6 +3156,32 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
       source-map-js: 1.2.1
+
+  maplibre-gl@5.15.0:
+    dependencies:
+      '@mapbox/geojson-rewind': 0.5.2
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.0.7
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/maplibre-gl-style-spec': 24.4.1
+      '@maplibre/mlt': 1.1.2
+      '@maplibre/vt-pbf': 4.2.0
+      '@types/geojson': 7946.0.16
+      '@types/geojson-vt': 3.2.5
+      '@types/supercluster': 7.1.3
+      earcut: 3.0.2
+      geojson-vt: 4.0.2
+      gl-matrix: 3.4.4
+      kdbush: 4.0.2
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      supercluster: 8.0.1
+      tinyqueue: 3.0.0
 
   markdown-table@3.0.4: {}
 
@@ -3282,11 +3507,15 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  minimist@1.2.8: {}
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
+
+  murmurhash-js@1.0.0: {}
 
   nanoid@3.3.11: {}
 
@@ -3358,6 +3587,10 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
@@ -3372,6 +3605,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@2.1.0: {}
+
   prettier@3.7.4: {}
 
   prismjs@1.30.0: {}
@@ -3385,7 +3620,11 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  protocol-buffers-schema@3.6.0: {}
+
   queue-microtask@1.2.3: {}
+
+  quickselect@3.0.0: {}
 
   radix3@1.1.2: {}
 
@@ -3475,6 +3714,10 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.0
+
   restructure@3.0.2: {}
 
   retext-latin@4.0.0:
@@ -3533,6 +3776,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   sax@1.4.3: {}
 
@@ -3613,6 +3858,10 @@ snapshots:
     dependencies:
       ansi-regex: 6.1.0
 
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.0.2
+
   svgo@4.0.0:
     dependencies:
       commander: 11.1.0
@@ -3631,6 +3880,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyqueue@3.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/src/components/MembersMap.astro
+++ b/src/components/MembersMap.astro
@@ -120,6 +120,14 @@ const centroids = featureCollection(
           },
         });
 
+        map.on("mouseenter", "members-points", (e) => {
+          map.getCanvas().style.cursor = "pointer";
+        });
+
+        map.on("mouseleave", "members-points", () => {
+          map.getCanvas().style.cursor = "";
+        });
+
         map.on("click", "members-points", (e) => {
           const feature = e.features?.[0];
           const { properties, geometry } = feature!;

--- a/src/components/MembersMap.astro
+++ b/src/components/MembersMap.astro
@@ -93,7 +93,7 @@ const centroids = featureCollection(
               4,
               9,
             ],
-            "circle-color": "rgb(0, 100, 255)",
+            "circle-color": "rgb(0, 255, 0)",
             "circle-stroke-color": "white",
             "circle-stroke-width": 1,
           },

--- a/src/components/MembersMap.astro
+++ b/src/components/MembersMap.astro
@@ -44,8 +44,16 @@ const centroids = featureCollection(
 );
 ---
 
-<members-map data-members={JSON.stringify(centroids)}>
-  <div id="members-map" style="width: 100%; height: 400px;"></div>
+<members-map
+  id="members-map-container"
+  data-members={JSON.stringify(centroids)}
+>
+  <div id="members-map"></div>
+  <!-- show only if selectedCountry -->
+  <div id="info" style="display: none;">
+    <button id="close-info">×</button>
+    <div id="info-content"></div>
+  </div>
 </members-map>
 
 <script>
@@ -53,8 +61,20 @@ const centroids = featureCollection(
   import { style } from "../lib/map-style";
 
   class MembersMap extends HTMLElement {
+    selectedCountry: string | null = null;
+
     connectedCallback() {
       const members = this.dataset.members;
+
+      const infoElement = this.querySelector<HTMLDivElement>("#info");
+      const closeButton =
+        infoElement?.querySelector<HTMLButtonElement>("#close-info");
+      const infoContent =
+        infoElement?.querySelector<HTMLDivElement>("#info-content");
+      closeButton?.addEventListener("click", () => {
+        console.log("close info");
+        infoElement!.style.display = "none";
+      });
 
       const map = new maplibregl.Map({
         container: "members-map",
@@ -113,13 +133,16 @@ const centroids = featureCollection(
           const [lng, lat] = coords;
           const center = new LngLat(lng, lat);
 
-          new maplibregl.Popup()
-            .setLngLat(center)
-            .setHTML(
-              `<strong>${countryName} (${countryCode})</strong>
-              <ul style="margin: 0; padding-left: 0em; list-style-type: none;">${membersList}</ul>`
-            )
-            .addTo(map);
+          if (!infoContent || !infoElement) return;
+          infoContent.innerHTML = `
+            <h3>${countryName} (${countryCode})</h3>
+            <div class="marquee">
+              <ul class="members">
+                ${membersList}
+              </ul>
+            </div>
+          `;
+          infoElement.style.display = "flex";
 
           map.flyTo({
             center,
@@ -134,6 +157,92 @@ const centroids = featureCollection(
 </script>
 
 <style>
+  #members-map-container {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr auto;
+    overflow: hidden;
+  }
+  #members-map {
+    grid-column: 1 / -1;
+    grid-row: 1 / 2;
+    width: 100%;
+    height: 400px;
+  }
+  #info {
+    grid-column: 1 / -1;
+    grid-row: 2 / 3;
+    overflow: hidden;
+    gap: 0.5em;
+    align-items: center;
+
+    #info-content {
+      display: flex;
+      gap: 0.5em;
+    }
+
+    #close-info {
+      margin: 0;
+      padding: 0.1em;
+      background: white;
+      aspect-ratio: 1/1;
+      height: 1.25em;
+      border-radius: 100%;
+      font-size: 1.25em;
+      align-self: start;
+    }
+
+    h3 {
+      white-space: nowrap;
+      margin: 0;
+    }
+
+    .marquee {
+      overflow: hidden;
+      width: 100%;
+      position: relative;
+      &::before {
+        content: "";
+        position: absolute;
+        width: 2em;
+        height: 100%;
+        z-index: 100;
+        background: linear-gradient(
+          to right,
+          var(--background) 0%,
+          transparent 100%
+        );
+      }
+    }
+
+    ul.members {
+      list-style: none;
+      display: flex;
+      gap: 1rem;
+      white-space: nowrap;
+      margin: 0;
+      padding: 0 1em 0 2em;
+      width: max-content;
+      animation: marquee 20s linear infinite;
+      align-items: center;
+    }
+  }
+
+  /* reduce motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    ul.members {
+      animation: none;
+    }
+  }
+  @keyframes marquee {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(-100%);
+    }
+  }
+
   .maplibregl-map {
     font-family: var(--font-family-body);
   }

--- a/src/components/MembersMap.astro
+++ b/src/components/MembersMap.astro
@@ -190,6 +190,7 @@ const centroids = featureCollection(
       height: 1.25em;
       border-radius: 100%;
       font-size: 1.25em;
+      line-height: 1em;
       align-self: start;
     }
 

--- a/src/components/MembersMap.astro
+++ b/src/components/MembersMap.astro
@@ -93,6 +93,7 @@ const centroids = featureCollection(
         map.addSource("members", {
           type: "geojson",
           data: membersPerCountry,
+          promoteId: "countryCode",
           attribution:
             "<a href='https://www.naturalearthdata.com'>Natural Earth Data</a>",
         });
@@ -115,9 +116,37 @@ const centroids = featureCollection(
               9,
             ],
             "circle-color": "rgb(0, 100, 255)",
-            "circle-stroke-color": "white",
-            "circle-stroke-width": 1,
+            "circle-stroke-color": [
+              "case",
+              ["boolean", ["feature-state", "hover"], false],
+              "rgb(0, 255, 100)",
+              "white",
+            ],
+            "circle-stroke-width": [
+              "case",
+              ["boolean", ["feature-state", "hover"], false],
+              3,
+              1,
+            ],
           },
+        });
+
+        let hoveredCountryId: string | number | undefined | null = null;
+
+        map.on("mousemove", "members-points", (e) => {
+          if (e.features && e.features?.length > 0) {
+            if (hoveredCountryId) {
+              map.setFeatureState(
+                { source: "members", id: hoveredCountryId },
+                { hover: false }
+              );
+            }
+            hoveredCountryId = e.features[0].id;
+            map.setFeatureState(
+              { source: "members", id: hoveredCountryId },
+              { hover: true }
+            );
+          }
         });
 
         map.on("mouseenter", "members-points", (e) => {
@@ -126,6 +155,13 @@ const centroids = featureCollection(
 
         map.on("mouseleave", "members-points", () => {
           map.getCanvas().style.cursor = "";
+          if (hoveredCountryId) {
+            map.setFeatureState(
+              { source: "members", id: hoveredCountryId },
+              { hover: false }
+            );
+          }
+          hoveredCountryId = null;
         });
 
         map.on("click", "members-points", (e) => {

--- a/src/components/MembersMap.astro
+++ b/src/components/MembersMap.astro
@@ -3,6 +3,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import type { Member } from "./Memberslist.astro";
 import centroid from "@turf/centroid";
 import { featureCollection } from "@turf/helpers";
+import { getLargestPolygon } from "../lib/get-largest-polygon";
 
 interface Props {
   members: Member[];
@@ -31,12 +32,12 @@ const membersPerCountry = members.reduce(
 
 const centroids = featureCollection(
   world.features.flatMap((d) => {
-    const { properties, geometry } = d;
-    const countryCode = properties?.iso_a2;
-    const countryName = properties?.admin;
+    const { properties } = d;
+    const { iso_a2: countryCode, admin: countryName } = properties ?? {};
     const members = membersPerCountry.get(countryCode);
     if (!countryCode || !members) return [];
-    const feature = centroid(geometry, {
+    const largestPolygon = getLargestPolygon(d);
+    const feature = centroid(largestPolygon, {
       properties: { countryCode, countryName, members },
     });
     return feature;

--- a/src/components/MembersMap.astro
+++ b/src/components/MembersMap.astro
@@ -58,7 +58,7 @@ const centroids = featureCollection(
 </members-map>
 
 <script>
-  import maplibregl, { LngLat } from "maplibre-gl";
+  import maplibregl, { LngLat, type LngLatLike } from "maplibre-gl";
   import { style } from "../lib/map-style";
 
   class MembersMap extends HTMLElement {
@@ -77,12 +77,22 @@ const centroids = featureCollection(
         infoElement!.style.display = "none";
       });
 
+      const initialViewCandidates = [
+        { center: [-40, 30], zoom: 1.5 },
+        { center: [96, 20], zoom: 1.6 },
+        { center: [-71, 0], zoom: 1.7 },
+      ] satisfies { center: LngLatLike; zoom: number }[];
+
+      const initialView =
+        initialViewCandidates[
+          Math.floor(Math.random() * initialViewCandidates.length)
+        ];
       const map = new maplibregl.Map({
         container: "members-map",
         style: style,
-        center: [-40, 30],
+        center: initialView.center,
         bearing: 180,
-        zoom: 1.5,
+        zoom: initialView.zoom,
         scrollZoom: false,
         boxZoom: false,
         doubleClickZoom: false,

--- a/src/components/MembersMap.astro
+++ b/src/components/MembersMap.astro
@@ -80,7 +80,8 @@ const centroids = featureCollection(
       const map = new maplibregl.Map({
         container: "members-map",
         style: style,
-        center: [0, 20],
+        center: [-40, 30],
+        bearing: 180,
         zoom: 1.5,
         scrollZoom: false,
         boxZoom: false,
@@ -203,6 +204,7 @@ const centroids = featureCollection(
 
 <style>
   #members-map-container {
+    margin: var(--spacing) 0;
     display: grid;
     grid-template-columns: 1fr;
     grid-template-rows: 1fr auto;

--- a/src/components/MembersMap.astro
+++ b/src/components/MembersMap.astro
@@ -1,0 +1,140 @@
+---
+import "maplibre-gl/dist/maplibre-gl.css";
+import type { Member } from "./Memberslist.astro";
+import centroid from "@turf/centroid";
+import { featureCollection } from "@turf/helpers";
+
+interface Props {
+  members: Member[];
+}
+
+const response = await fetch(
+  "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_admin_0_countries.geojson"
+);
+const world: Awaited<GeoJSON.FeatureCollection<GeoJSON.MultiPolygon>> =
+  await response.json();
+
+const { members } = Astro.props;
+
+const membersPerCountry = members.reduce(
+  (acc: Map<string, Member[]>, member) => {
+    const country = member.country;
+    if (!country) return acc;
+    if (!acc.get(country)) {
+      acc.set(country, []);
+    }
+    acc.get(country)!.push(member);
+    return acc;
+  },
+  new Map<string, Member[]>()
+);
+
+const centroids = featureCollection(
+  world.features.flatMap((d) => {
+    const { properties, geometry } = d;
+    const countryCode = properties?.iso_a2;
+    const countryName = properties?.admin;
+    const members = membersPerCountry.get(countryCode);
+    if (!countryCode || !members) return [];
+    const feature = centroid(geometry, {
+      properties: { countryCode, countryName, members },
+    });
+    return feature;
+  })
+);
+---
+
+<members-map data-members={JSON.stringify(centroids)}>
+  <div id="members-map" style="width: 100%; height: 400px;"></div>
+</members-map>
+
+<script>
+  import maplibregl, { LngLat } from "maplibre-gl";
+  import { style } from "../lib/map-style";
+
+  class MembersMap extends HTMLElement {
+    connectedCallback() {
+      const members = this.dataset.members;
+
+      const map = new maplibregl.Map({
+        container: "members-map",
+        style: style,
+        center: [0, 20],
+        zoom: 1.5,
+        scrollZoom: false,
+        boxZoom: false,
+        doubleClickZoom: false,
+      });
+
+      map.on("load", () => {
+        const membersPerCountry = JSON.parse(members ?? "");
+
+        map.addSource("members", {
+          type: "geojson",
+          data: membersPerCountry,
+          attribution:
+            "<a href='https://www.naturalearthdata.com'>Natural Earth Data</a>",
+        });
+        map.addLayer({
+          id: "members-points",
+          type: "circle",
+          source: "members",
+          paint: {
+            "circle-radius": [
+              "step",
+              ["length", ["get", "members"]],
+              0,
+              1,
+              3,
+              2,
+              5,
+              3,
+              7,
+              4,
+              9,
+            ],
+            "circle-color": "rgb(0, 100, 255)",
+            "circle-stroke-color": "white",
+            "circle-stroke-width": 1,
+          },
+        });
+
+        map.on("click", "members-points", (e) => {
+          const feature = e.features?.[0];
+          const { properties, geometry } = feature!;
+          const { members, countryName, countryCode } = properties;
+          const membersList = JSON.parse(members)
+            .map((m: { name: string }) => `<li>${m.name}</li>`)
+            .join("");
+
+          // guard and narrow to Point before accessing coordinates
+          if (!geometry || geometry.type !== "Point") return;
+          const coords = (geometry as GeoJSON.Point).coordinates;
+          const [lng, lat] = coords;
+          const center = new LngLat(lng, lat);
+
+          new maplibregl.Popup()
+            .setLngLat(center)
+            .setHTML(
+              `<strong>${countryName} (${countryCode})</strong>
+              <ul style="margin: 0; padding-left: 0em; list-style-type: none;">${membersList}</ul>`
+            )
+            .addTo(map);
+
+          map.flyTo({
+            center,
+            essential: true,
+          });
+        });
+      });
+    }
+  }
+
+  customElements.define("members-map", MembersMap);
+</script>
+
+<style>
+  .maplibregl-map {
+    font-family: var(--font-family-body);
+  }
+</style>

--- a/src/components/MembersMap.astro
+++ b/src/components/MembersMap.astro
@@ -114,7 +114,7 @@ const centroids = featureCollection(
               4,
               9,
             ],
-            "circle-color": "rgb(0, 255, 0)",
+            "circle-color": "rgb(0, 100, 255)",
             "circle-stroke-color": "white",
             "circle-stroke-width": 1,
           },

--- a/src/components/Memberslist.astro
+++ b/src/components/Memberslist.astro
@@ -1,9 +1,42 @@
 ---
-import { Content } from "../data/members.md";
+import { frontmatter, Content } from "../data/members.md";
+import Callout from "./Callout.astro";
+
+const members = frontmatter.members as {
+  name: string;
+  website?: string;
+  affiliation?: string;
+  country?: string;
+}[];
 ---
 
 <div class="shuffle">
   <Content />
+  <Callout style={{ margin: "2em 0 3em" }}>
+    <span class="monospace text-bold">Note</span>
+    <p>
+      If you want to be added to the this section please contact us or create a
+      pull request on our
+      <a
+        href="https://github.com/next-generation-cartographers/next-generation-cartographers.github.io"
+        >github repository</a
+      >.
+    </p>
+  </Callout>
+  <ul class="shuffle">
+    {
+      members.map((member) => {
+        const { name, website, affiliation, country } = member;
+        const info = `${affiliation ? affiliation + ",\u00A0" : ""}${country ? country : ""}`;
+        return (
+          <li>
+            {website ? <a href={website}>{name}</a> : name}{" "}
+            {info ? <em>({info})</em> : null}
+          </li>
+        );
+      })
+    }
+  </ul>
 </div>
 
 <!-- TODO: find out how to style Content without using is:global -->

--- a/src/components/Memberslist.astro
+++ b/src/components/Memberslist.astro
@@ -27,6 +27,7 @@ const members = frontmatter.members as Member[];
       >.
     </p>
   </Callout>
+  <p>The members are shown in randomized order on every page load.</p>
   <ul class="shuffle">
     {
       members.map((member) => {

--- a/src/components/Memberslist.astro
+++ b/src/components/Memberslist.astro
@@ -1,17 +1,21 @@
 ---
 import { frontmatter, Content } from "../data/members.md";
 import Callout from "./Callout.astro";
+import MembersMap from "./MembersMap.astro";
 
-const members = frontmatter.members as {
+export type Member = {
   name: string;
   website?: string;
   affiliation?: string;
   country?: string;
-}[];
+};
+
+const members = frontmatter.members as Member[];
 ---
 
 <div class="shuffle">
   <Content />
+  <MembersMap members={members} />
   <Callout style={{ margin: "2em 0 3em" }}>
     <span class="monospace text-bold">Note</span>
     <p>
@@ -42,7 +46,7 @@ const members = frontmatter.members as {
 <!-- TODO: find out how to style Content without using is:global -->
 <style is:global>
   @media screen and (min-width: 680px) {
-    .shuffle ul {
+    ul.shuffle {
       columns: 2;
       gap: 4em;
     }

--- a/src/components/Memberslist.astro
+++ b/src/components/Memberslist.astro
@@ -13,7 +13,7 @@ export type Member = {
 const members = frontmatter.members as Member[];
 ---
 
-<div class="shuffle">
+<div>
   <Content />
   <MembersMap members={members} />
   <Callout style={{ margin: "2em 0 3em" }}>

--- a/src/data/members.md
+++ b/src/data/members.md
@@ -120,4 +120,4 @@ members:
 
 ## Members
 
-The members are shown in randomized order on every page load.
+As NGC we advocate for young cartographers across the globe. Here is a list of our current members. We would love to expand our network even further, so please don't hesitate to reach out if you are interested in joining!

--- a/src/data/members.md
+++ b/src/data/members.md
@@ -1,29 +1,123 @@
-- [Chelsea Nestel](https://library.uoregon.edu/directory/nestel) _(**Co-chair**; University of Oregon,&nbsp;US)_
-- [Katarzyna Słomska-Przech](https://ihpan.edu.pl/en/employees/researcher/katarzyna-slomska-przech-2/) _(**Co-chair**; Polska Akademia Nauk,&nbsp;PL)_
-- [Merve Keskin](https://drmervekeskin.com) _(University of Salzburg,&nbsp;AT)_
-- [Jakob Listabarth](<https://fis.tu-dresden.de/portal/de/researchers/jakob-listabarth(a6ce5107-8ec5-4fa1-82bc-f05f6d72bb14).html>) _(TU Dresden,&nbsp;DE)_
-- [Florian Ledermann](https://cartography.tuwien.ac.at/florian-ledermann/) _(TU Wien,&nbsp;AT)_
-- [Nianhua Liu](https://www.asg.ed.tum.de/en/lfk/team/members/nianhua-liu/) _(TU Munich,&nbsp;DE)_
-- [Héctor Ochoa Ortiz](https://odeco-research.eu/?p=3170) _(University of Camerino,&nbsp;IT)_
-- [Ester Scheck](https://cartography.tuwien.ac.at/ester-scheck/) _(TU Wien,&nbsp;AT)_
-- [Sacha Schlumpf](https://sacha-schlumpf.ch/) _(TU Wien,&nbsp;AT)_
-- [Zulfa Nur’aini ‘Afifah](https://zulfanaa.github.io/portfolio/) _(University of Augsburg,&nbsp;DE)_
-- [Juliane Cron](https://www.asg.ed.tum.de/lfk/team/members/juliane-cron/) _(TU Munich,&nbsp;DE)_
-- Andrea Miletić _(Faculty of Geodesy, University of Zagreb,&nbsp;HR)_
-- [Bella Mironova](https://github.com/bella-mir) _(National Research University HSE,&nbsp;RU)_
-- [Camila Narbaitz Sarsur](https://www.cnscartography.com/) _(AR)_
-- Dajana Snopková _(Department of Geography, Masaryk University,&nbsp;CZ)_
-- [Estelle Sérèmes](https://es1010.github.io/Prive/?v=2) _(Agroparistech,&nbsp;FR)_
-- [Iga Ajdacka](http://geoinformatics.uw.edu.pl/iga-ajdacka/) _(University of Warsaw,&nbsp;PL)_
-- [Jakub Wabiński](https://www.linkedin.com/in/jakub-wabi%C5%84ski-engd-40a5b7a9/) _(Military University of Technology,&nbsp;PL)_
-- [Lydia Yoder](https://www.yodermapping.com/) _(US)_
-- [Mert Turunç](https://blog.atr0p.dev) _(Istanbul Technical University,&nbsp;TR)_
-- Nat Slaughter
-- Natalia Ipatow
-- [Nicolás Martínez Heredia](https://cartography.tuwien.ac.at/staff/nicolas-martinez-heredia/) _(TU Wien,&nbsp;AT)_
-- Nina Polous _(Uni Graz,&nbsp;AT)_
-- Sagnik Mukherjee _(GeoSN,&nbsp;DE)_
-- [Samuel Darkwah Manu](https://sammyhawkrad.github.io) _(TU Dresden,&nbsp;DE)_
-- [Tatiana Pozdnyakova](https://readymag.website/u1754210549/tanyapozdniakova/)
-- Wangshu Wang _(TU Munich,&nbsp;DE)_
-- [Zihan Liu](https://www.asg.ed.tum.de/lfk/team/members/zihan-liu/) _(TU Munich,&nbsp;DE)_
+---
+members:
+  - name: "Chelsea Nestel"
+    website: "https://library.uoregon.edu/directory/nestel"
+    affiliation: "University of Oregon"
+    country: "US"
+  - name: "Katarzyna Słomska-Przech"
+    website: "https://ihpan.edu.pl/en/employees/researcher/katarzyna-slomska-przech-2/"
+    affiliation: "Polska Akademia Nauk"
+    country: "PL"
+  - name: "Merve Keskin"
+    website: "https://drmervekeskin.com"
+    affiliation: "University of Salzburg"
+    country: "AT"
+  - name: "Jakob Listabarth"
+    website: "https://fis.tu-dresden.de/portal/de/researchers/jakob-listabarth(a6ce5107-8ec5-4fa1-82bc-f05f6d72bb14).html"
+    affiliation: "TU Dresden"
+    country: "DE"
+  - name: "Florian Ledermann"
+    website: "https://cartography.tuwien.ac.at/florian-ledermann/"
+    affiliation: "TU Wien"
+    country: "AT"
+  - name: "Nianhua Liu"
+    website: "https://www.asg.ed.tum.de/en/lfk/team/members/nianhua-liu/"
+    affiliation: "TU Munich"
+    country: "DE"
+  - name: "Héctor Ochoa Ortiz"
+    website: "https://odeco-research.eu/?p=3170"
+    affiliation: "University of Camerino"
+    country: "IT"
+  - name: "Ester Scheck"
+    website: "https://cartography.tuwien.ac.at/ester-scheck/"
+    affiliation: "TU Wien"
+    country: "AT"
+  - name: "Sacha Schlumpf"
+    website: "https://sacha-schlumpf.ch/"
+    affiliation: "TU Wien"
+    country: "AT"
+  - name: "Zulfa Nur’aini ‘Afifah"
+    website: "https://zulfanaa.github.io/portfolio/"
+    affiliation: "University of Augsburg"
+    country: "DE"
+  - name: "Juliane Cron"
+    website: "https://www.asg.ed.tum.de/lfk/team/members/juliane-cron/"
+    affiliation: "TU Munich"
+    country: "DE"
+  - name: "Andrea Miletić"
+    website: null
+    affiliation: "Faculty of Geodesy, University of Zagreb"
+    country: "HR"
+  - name: "Bella Mironova"
+    website: "https://github.com/bella-mir"
+    affiliation: "National Research University HSE"
+    country: "RU"
+  - name: "Camila Narbaitz Sarsur"
+    website: "https://www.cnscartography.com/"
+    affiliation: ""
+    country: "AR"
+  - name: "Dajana Snopková"
+    website: null
+    affiliation: "Department of Geography, Masaryk University"
+    country: "CZ"
+  - name: "Estelle Sérèmes"
+    website: "https://es1010.github.io/Prive/?v=2"
+    affiliation: "Agroparistech"
+    country: "FR"
+  - name: "Iga Ajdacka"
+    website: "http://geoinformatics.uw.edu.pl/iga-ajdacka/"
+    affiliation: "University of Warsaw"
+    country: "PL"
+  - name: "Jakub Wabiński"
+    website: "https://www.linkedin.com/in/jakub-wabi%C5%84ski-engd-40a5b7a9/"
+    affiliation: "Military University of Technology"
+    country: "PL"
+  - name: "Lydia Yoder"
+    website: "https://www.yodermapping.com/"
+    affiliation: ""
+    country: "US"
+  - name: "Mert Turunç"
+    website: "https://blog.atr0p.dev"
+    affiliation: "Istanbul Technical University"
+    country: "TR"
+  - name: "Nat Slaughter"
+    website: null
+    affiliation: ""
+    country: ""
+  - name: "Natalia Ipatow"
+    website: null
+    affiliation: ""
+    country: ""
+  - name: "Nicolás Martínez Heredia"
+    website: "https://cartography.tuwien.ac.at/staff/nicolas-martinez-heredia/"
+    affiliation: "TU Wien"
+    country: "AT"
+  - name: "Nina Polous"
+    website: null
+    affiliation: "Uni Graz"
+    country: "AT"
+  - name: "Sagnik Mukherjee"
+    website: null
+    affiliation: "GeoSN"
+    country: "DE"
+  - name: "Samuel Darkwah Manu"
+    website: "https://sammyhawkrad.github.io"
+    affiliation: "TU Dresden"
+    country: "DE"
+  - name: "Tatiana Pozdnyakova"
+    website: "https://readymag.website/u1754210549/tanyapozdniakova/"
+    affiliation: ""
+    country: ""
+  - name: "Wangshu Wang"
+    website: null
+    affiliation: "TU Munich"
+    country: "DE"
+  - name: "Zihan Liu"
+    website: "https://www.asg.ed.tum.de/lfk/team/members/zihan-liu/"
+    affiliation: "TU Munich"
+    country: "DE"
+---
+
+## Members
+
+The members are shown in randomized order on every page load.

--- a/src/lib/get-largest-polygon.ts
+++ b/src/lib/get-largest-polygon.ts
@@ -1,0 +1,36 @@
+const ringArea = (ring: number[][]): number => {
+  let area = 0;
+  const n = ring.length;
+  for (let i = 0; i < n; i++) {
+    const [x1, y1] = ring[i];
+    const [x2, y2] = ring[(i + 1) % n];
+    area += x1 * y2 - x2 * y1;
+  }
+  return Math.abs(area) / 2;
+};
+
+export const getLargestPolygon = (
+  feature: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>
+): GeoJSON.Feature<GeoJSON.Polygon> => {
+  if (feature.geometry.type === "Polygon") {
+    return feature as GeoJSON.Feature<GeoJSON.Polygon>;
+  } else {
+    let largestArea = -Infinity;
+    let largestPolygon: GeoJSON.Polygon | null = null;
+    for (const polygon of feature.geometry.coordinates) {
+      const area = ringArea(polygon[0]);
+      if (area > largestArea) {
+        largestArea = area;
+        largestPolygon = {
+          type: "Polygon",
+          coordinates: polygon,
+        };
+      }
+    }
+    return {
+      type: "Feature",
+      properties: feature.properties,
+      geometry: largestPolygon!,
+    };
+  }
+};

--- a/src/lib/map-style.ts
+++ b/src/lib/map-style.ts
@@ -1,7 +1,7 @@
 import type { StyleSpecification } from "maplibre-gl";
 
-const waterColor = "rgb(255, 255, 255)";
-const landmassColor = "hsla(216, 100%, 90%, 1.00)";
+const waterColor = "hsl(216, 100%, 90%)";
+const landmassColor = "rgb(255, 255, 255)";
 
 // based on the style "Libeerty" by OpenFreeMap (https://openfreemap.org)
 // licensed under CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
@@ -27,6 +27,22 @@ export const style: StyleSpecification = {
       id: "background",
       type: "background",
       paint: { "background-color": landmassColor },
+    },
+    {
+      id: "water-shadow",
+      type: "fill",
+      source: "openmaptiles",
+      "source-layer": "water",
+      filter: ["!=", ["get", "brunnel"], "tunnel"],
+      paint: { "fill-color": "rgb(0, 100, 255)", "fill-translate": [0, 0.5] },
+    },
+    {
+      id: "water-reflection",
+      type: "fill",
+      source: "openmaptiles",
+      "source-layer": "water",
+      filter: ["!=", ["get", "brunnel"], "tunnel"],
+      paint: { "fill-color": "hsl(216, 100%, 95%)", "fill-translate": [0, -1] },
     },
     {
       id: "water",

--- a/src/lib/map-style.ts
+++ b/src/lib/map-style.ts
@@ -1,5 +1,8 @@
 import type { StyleSpecification } from "maplibre-gl";
 
+const waterColor = "rgb(0, 100, 255)";
+const landmassColor = "rgb(255,255,255)";
+
 // based on the style "Libeerty" by OpenFreeMap (https://openfreemap.org)
 // licensed under CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
 export const style: StyleSpecification = {
@@ -23,74 +26,15 @@ export const style: StyleSpecification = {
     {
       id: "background",
       type: "background",
-      paint: { "background-color": "#f8f4f0" },
+      paint: { "background-color": landmassColor },
     },
     {
-      id: "natural_earth",
-      type: "raster",
-      source: "ne2_shaded",
-      maxzoom: 7,
-      paint: {
-        "raster-opacity": [
-          "interpolate",
-          ["exponential", 1.5],
-          ["zoom"],
-          0,
-          0.6,
-          6,
-          0.1,
-        ],
-      },
-    },
-    {
-      id: "landcover_wood",
+      id: "water",
       type: "fill",
       source: "openmaptiles",
-      "source-layer": "landcover",
-      filter: ["==", ["get", "class"], "wood"],
-      paint: {
-        "fill-antialias": false,
-        "fill-color": "hsla(98,61%,72%,0.7)",
-        "fill-opacity": 0.4,
-      },
-    },
-    {
-      id: "landcover_grass",
-      type: "fill",
-      source: "openmaptiles",
-      "source-layer": "landcover",
-      filter: ["==", ["get", "class"], "grass"],
-      paint: {
-        "fill-antialias": false,
-        "fill-color": "rgba(176, 213, 154, 1)",
-        "fill-opacity": 0.3,
-      },
-    },
-    {
-      id: "landcover_ice",
-      type: "fill",
-      source: "openmaptiles",
-      "source-layer": "landcover",
-      filter: ["==", ["get", "class"], "ice"],
-      paint: {
-        "fill-antialias": false,
-        "fill-color": "rgba(240, 255, 255, 1)",
-        "fill-opacity": 0.8,
-      },
-    },
-    {
-      id: "landcover_wetland",
-      type: "fill",
-      source: "openmaptiles",
-      "source-layer": "landcover",
-      minzoom: 12,
-      filter: ["==", ["get", "class"], "wetland"],
-      paint: {
-        "fill-antialias": true,
-        "fill-opacity": 0.8,
-        "fill-pattern": "wetland_bg_11",
-        "fill-translate-anchor": "map",
-      },
+      "source-layer": "water",
+      filter: ["!=", ["get", "brunnel"], "tunnel"],
+      paint: { "fill-color": waterColor },
     },
     {
       id: "waterway_river",
@@ -104,7 +48,7 @@ export const style: StyleSpecification = {
       ],
       layout: { "line-cap": "round" },
       paint: {
-        "line-color": "#a0c8f0",
+        "line-color": waterColor,
         "line-width": [
           "interpolate",
           ["exponential", 1.2],
@@ -128,7 +72,7 @@ export const style: StyleSpecification = {
       ],
       layout: { "line-cap": "round" },
       paint: {
-        "line-color": "#a0c8f0",
+        "line-color": waterColor,
         "line-width": [
           "interpolate",
           ["exponential", 1.3],
@@ -139,22 +83,6 @@ export const style: StyleSpecification = {
           6,
         ],
       },
-    },
-    {
-      id: "water",
-      type: "fill",
-      source: "openmaptiles",
-      "source-layer": "water",
-      filter: ["!=", ["get", "brunnel"], "tunnel"],
-      paint: { "fill-color": "hsl(216.9, 100%, 95.5%)" },
-    },
-    {
-      id: "landcover_sand",
-      type: "fill",
-      source: "openmaptiles",
-      "source-layer": "landcover",
-      filter: ["==", ["get", "class"], "sand"],
-      paint: { "fill-color": "rgba(247, 239, 195, 1)" },
     },
   ],
 };

--- a/src/lib/map-style.ts
+++ b/src/lib/map-style.ts
@@ -29,22 +29,6 @@ export const style: StyleSpecification = {
       paint: { "background-color": landmassColor },
     },
     {
-      id: "water-shadow",
-      type: "fill",
-      source: "openmaptiles",
-      "source-layer": "water",
-      filter: ["!=", ["get", "brunnel"], "tunnel"],
-      paint: { "fill-color": "rgb(0, 100, 255)", "fill-translate": [0, 0.5] },
-    },
-    {
-      id: "water-reflection",
-      type: "fill",
-      source: "openmaptiles",
-      "source-layer": "water",
-      filter: ["!=", ["get", "brunnel"], "tunnel"],
-      paint: { "fill-color": "hsl(216, 100%, 95%)", "fill-translate": [0, -1] },
-    },
-    {
       id: "water",
       type: "fill",
       source: "openmaptiles",

--- a/src/lib/map-style.ts
+++ b/src/lib/map-style.ts
@@ -1,0 +1,160 @@
+import type { StyleSpecification } from "maplibre-gl";
+
+// based on the style "Libeerty" by OpenFreeMap (https://openfreemap.org)
+// licensed under CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
+export const style: StyleSpecification = {
+  version: 8,
+  projection: { type: "globe" },
+  sources: {
+    ne2_shaded: {
+      maxzoom: 6,
+      tileSize: 256,
+      tiles: [
+        "https://tiles.openfreemap.org/natural_earth/ne2sr/{z}/{x}/{y}.png",
+      ],
+      type: "raster",
+    },
+    openmaptiles: {
+      type: "vector",
+      url: "https://tiles.openfreemap.org/planet",
+    },
+  },
+  layers: [
+    {
+      id: "background",
+      type: "background",
+      paint: { "background-color": "#f8f4f0" },
+    },
+    {
+      id: "natural_earth",
+      type: "raster",
+      source: "ne2_shaded",
+      maxzoom: 7,
+      paint: {
+        "raster-opacity": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          0,
+          0.6,
+          6,
+          0.1,
+        ],
+      },
+    },
+    {
+      id: "landcover_wood",
+      type: "fill",
+      source: "openmaptiles",
+      "source-layer": "landcover",
+      filter: ["==", ["get", "class"], "wood"],
+      paint: {
+        "fill-antialias": false,
+        "fill-color": "hsla(98,61%,72%,0.7)",
+        "fill-opacity": 0.4,
+      },
+    },
+    {
+      id: "landcover_grass",
+      type: "fill",
+      source: "openmaptiles",
+      "source-layer": "landcover",
+      filter: ["==", ["get", "class"], "grass"],
+      paint: {
+        "fill-antialias": false,
+        "fill-color": "rgba(176, 213, 154, 1)",
+        "fill-opacity": 0.3,
+      },
+    },
+    {
+      id: "landcover_ice",
+      type: "fill",
+      source: "openmaptiles",
+      "source-layer": "landcover",
+      filter: ["==", ["get", "class"], "ice"],
+      paint: {
+        "fill-antialias": false,
+        "fill-color": "rgba(240, 255, 255, 1)",
+        "fill-opacity": 0.8,
+      },
+    },
+    {
+      id: "landcover_wetland",
+      type: "fill",
+      source: "openmaptiles",
+      "source-layer": "landcover",
+      minzoom: 12,
+      filter: ["==", ["get", "class"], "wetland"],
+      paint: {
+        "fill-antialias": true,
+        "fill-opacity": 0.8,
+        "fill-pattern": "wetland_bg_11",
+        "fill-translate-anchor": "map",
+      },
+    },
+    {
+      id: "waterway_river",
+      type: "line",
+      source: "openmaptiles",
+      "source-layer": "waterway",
+      filter: [
+        "all",
+        ["==", ["get", "class"], "river"],
+        ["!=", ["get", "brunnel"], "tunnel"],
+      ],
+      layout: { "line-cap": "round" },
+      paint: {
+        "line-color": "#a0c8f0",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.2],
+          ["zoom"],
+          11,
+          0.5,
+          20,
+          6,
+        ],
+      },
+    },
+    {
+      id: "waterway_other",
+      type: "line",
+      source: "openmaptiles",
+      "source-layer": "waterway",
+      filter: [
+        "all",
+        ["!=", ["get", "class"], "river"],
+        ["!=", ["get", "brunnel"], "tunnel"],
+      ],
+      layout: { "line-cap": "round" },
+      paint: {
+        "line-color": "#a0c8f0",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.3],
+          ["zoom"],
+          13,
+          0.5,
+          20,
+          6,
+        ],
+      },
+    },
+    {
+      id: "water",
+      type: "fill",
+      source: "openmaptiles",
+      "source-layer": "water",
+      filter: ["!=", ["get", "brunnel"], "tunnel"],
+      paint: { "fill-color": "hsl(216.9, 100%, 95.5%)" },
+    },
+    {
+      id: "landcover_sand",
+      type: "fill",
+      source: "openmaptiles",
+      "source-layer": "landcover",
+      filter: ["==", ["get", "class"], "sand"],
+      paint: { "fill-color": "rgba(247, 239, 195, 1)" },
+    },
+  ],
+};

--- a/src/lib/map-style.ts
+++ b/src/lib/map-style.ts
@@ -1,7 +1,7 @@
 import type { StyleSpecification } from "maplibre-gl";
 
-const waterColor = "rgb(0, 100, 255)";
-const landmassColor = "rgb(255,255,255)";
+const waterColor = "rgb(255, 255, 255)";
+const landmassColor = "hsla(216, 100%, 90%, 1.00)";
 
 // based on the style "Libeerty" by OpenFreeMap (https://openfreemap.org)
 // licensed under CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/)

--- a/src/pages/about/terms-of-reference.astro
+++ b/src/pages/about/terms-of-reference.astro
@@ -160,3 +160,24 @@ import NgcLogo from "../../components/NgcLogo.astro";
     </ul>
   </details>
 </Layout>
+
+<style>
+  details {
+    border: 1px solid var(--muted);
+    border-radius: var(--border-radius-sm);
+    padding: 0.5em 2em 0;
+    margin-top: 2em;
+    max-width: var(--width-prose);
+  }
+
+  summary {
+    font-weight: bold;
+    margin: -0.5em -2em 0;
+    padding: var(--spacing-xs) var(--spacing);
+  }
+
+  details[open] summary {
+    border-bottom: 1px solid var(--muted);
+    margin-bottom: var(--spacing-xs);
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,5 @@
 ---
 import { getCollection } from "astro:content";
-import Callout from "../components/Callout.astro";
 import Disclaimer from "../components/Disclaimer.astro";
 import LinkCard from "../components/LinkCard.astro";
 import MeetUpList from "../components/MeetupList.astro";
@@ -98,21 +97,9 @@ const updates = (await getCollection("updates")).toSorted(
     }
   </ul>
 
-  <h2 id="members">Members</h2>
-  <p>The members are shown in randomized order on every page load.</p>
-  <Memberslist />
-
-  <Callout style={{ marginTop: "2em" }}>
-    <span class="monospace text-bold">Note</span>
-    <p>
-      If you want to be added to the this section please contact us or create a
-      pull request on our
-      <a
-        href="https://github.com/next-generation-cartographers/next-generation-cartographers.github.io"
-        >github repository</a
-      >.
-    </p>
-  </Callout>
+  <div id="members">
+    <Memberslist />
+  </div>
 
   <style>
     p.teaser {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -131,25 +131,6 @@ code {
   color: var(--muted);
 }
 
-details {
-  border: 1px solid var(--muted);
-  border-radius: var(--border-radius-sm);
-  padding: 0.5em 2em 0;
-  margin-top: 2em;
-  max-width: var(--width-prose);
-}
-
-summary {
-  font-weight: bold;
-  margin: -0.5em -2em 0;
-  padding: var(--spacing-xs) var(--spacing);
-}
-
-details[open] summary {
-  border-bottom: 1px solid var(--muted);
-  margin-bottom: var(--spacing-xs);
-}
-
 ul.link-list {
   padding-left: 0;
   list-style: none;


### PR DESCRIPTION
Add an interactive map using maplibre and its globe projection to show the origin of members.

This PR adds several dependencies: maplibre, turf helpers etc. 

## To-Dos
- [ ]  Reconsider style: I had another variant which used landcover (feel like it did not suit to the surrounding colors)
- [ ] reconsider centroid approach (see France)
- [ ] optional: refactor to use separate component for info element